### PR TITLE
Switch ruby github action to docker-images repo

### DIFF
--- a/ruby/action.yml
+++ b/ruby/action.yml
@@ -15,11 +15,11 @@ inputs:
     default: false
 runs:
   using: "docker"
-  image: "docker://snyk/snyk:ruby"
+  image: "docker://docker.pkg.github.com/zendesk/dockerhub-images/snyk:ruby"
   env:
     SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
     SNYK_INTEGRATION_VERSION: ruby
   args:
   - snyk
   - ${{ inputs.command }}
-  - ${{ inputs.args }} 
+  - ${{ inputs.args }}


### PR DESCRIPTION
Switches the ruby action to pull from the docker-images repo rather than dockerhub, avoiding issues with dockerhub rate limiting.